### PR TITLE
Simplify acpica installation

### DIFF
--- a/dsdt.patch
+++ b/dsdt.patch
@@ -1,70 +1,6 @@
---- dsdt.dsl	2020-08-11 11:34:59.394093455 +0700
-+++ dsdt_fix.dsl	2020-08-11 11:30:23.635049000 +0700
-@@ -1,63 +1,3 @@
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.VER1], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.VER2], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI0], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI1], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI2], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI3], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI4], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI5], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI6], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI7], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI8], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI9], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIA], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIB], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIC], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGID], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIE], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIF], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.CCI0], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.CCI1], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.CCI2], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.CCI3], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS0], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS1], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS2], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS3], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS4], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS5], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS6], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS7], AE_NOT_FOUND (20200717/dswload-495)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.VER1], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.VER2], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI0], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI1], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI2], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI3], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI4], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI5], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI6], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI7], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI8], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGI9], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIA], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIB], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIC], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGID], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIE], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.MGIF], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.CCI0], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.CCI1], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.CCI2], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.CCI3], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS0], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS1], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS2], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS3], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS4], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS5], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS6], AE_NOT_FOUND (20200717/dswload2-479)
--Firmware Error (ACPI): Could not resolve symbol [^^^UBTC.STS7], AE_NOT_FOUND (20200717/dswload2-479)
- /*
-  * Intel ACPI Component Architecture
-  * AML/ASL+ Disassembler version 20200717 (64-bit version)
-@@ -78,7 +18,7 @@
+--- dsdt.dsl	2020-12-30 22:10:06.945246639 +0100
++++ dsdt_fix.dsl	2020-12-30 22:10:02.033535952 +0100
+@@ -18,7 +18,7 @@
   *     Compiler ID      "    "
   *     Compiler Version 0x01000013 (16777235)
   */
@@ -73,7 +9,7 @@
  {
      External (_GPE, DeviceObj)
      External (_SB_.ALIB, MethodObj)    // 2 Arguments
-@@ -977,20 +917,13 @@
+@@ -917,20 +917,13 @@
          Zero, 
          Zero
      })
@@ -100,7 +36,7 @@
      Name (_S4, Package (0x04)  // _S4_: S4 System State
      {
          0x04, 
-@@ -11377,11 +11310,6 @@
+@@ -11317,11 +11310,6 @@
  
                                  Local0 |= One
                              }

--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ cp acpi_s3_override /boot/
 
 **6. Set the default sleep type to S3 (deep)**
 
-Open `etc/default/grub` and add `mem_sleep_default=deep` to `GRUB_CMDLINE_LINUX_DEFAULT` then run `update-grub`
+Open `/etc/default/grub` and add `mem_sleep_default=deep` to `GRUB_CMDLINE_LINUX_DEFAULT` then run `update-grub`
 
 Example:
 ```
@@ -162,7 +162,7 @@ GRUB_CMDLINE_LINUX_DEFAULT="quiet splash mem_sleep_default=deep"
 
 **Note: There's a [problem](grub-fix.md) in older version of grub shipped with Ubuntu, make sure you upgrade your system (`apt update && apt upgrade`) before performing this step** 
 
-Open `etc/default/grub` and add `acpi_s3_override` to `GRUB_EARLY_INITRD_LINUX_CUSTOM` then run `update-grub`
+Open `/etc/default/grub` and add `acpi_s3_override` to `GRUB_EARLY_INITRD_LINUX_CUSTOM` then run `update-grub`
 
 Example:
 ```

--- a/readme.md
+++ b/readme.md
@@ -93,22 +93,9 @@ sudo -i
 
 **1. Get the required tools**
 
-Download and compile from https://www.acpica.org/downloads
 ```bash
 # Install some required dependencies
-apt install m4 build-essential bison flex
-
-# Download and extract
-wget https://acpica.org/sites/acpica/files/acpica-unix-20200717.tar.gz
-tar -xvf acpica-unix-20200717.tar.gz
-cd acpica-unix-20200717
-
-# Make
-make clean
-make
-
-# Add to PATH for easy access
-PATH=$PATH:$(realpath ./generate/unix/bin/)
+apt install acpica-tools
 ```
 
 **2. Dump the ACPI files and decompile the DSDT table**
@@ -127,7 +114,16 @@ iasl -e *.dat -d dsdt.dat
 
 **3. Apply patch**
 
-Copy dsdt.patch from this repo and patch dsdt.dsl
+First, remove garbage from the source file:
+
+```bash
+sed -i '/^Firmware Error/d' dsdt.dsl
+```
+
+_(The exact content depends on the acpidump version.)_
+
+Then copy dsdt.patch from this repo and patch `dsdt.dsl`:
+
 ```bash
 patch <dsdt.patch
 ```


### PR DESCRIPTION
The acpica tools is provided by the `acpica-tools` package, there is no need to build it from sources.

However, the "Firmware Error" lines must be removed separately (via `sed`), since the exact content depends on the acpica version.

---

Note: tested on _Debian testing_, not _Ubuntu_, but the package is also available on _Ubuntu_.

Btw, thank you very much for the documentation!